### PR TITLE
Add BrochurePreview test, setup test, test helpers and test utils

### DIFF
--- a/src/components/ui/__tests__/BrochurePreview.test.tsx
+++ b/src/components/ui/__tests__/BrochurePreview.test.tsx
@@ -1,0 +1,107 @@
+import { screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '../../../test/test-utils'
+import { BrochurePreview } from '../BrochurePreview'
+import { useBrochureStore } from '../../../stores/useBrochureStore'
+import { describe, beforeEach, it, expect, vi } from 'vitest'
+import type { BrochureState } from '../../../stores/useBrochureStore'
+import { setLanguage, selectButtonByName, makePdfBlob, withBlobUrlSpies } from '../../../test/test-helpers'
+
+// Mock the useBrochureDownload hook
+const mockDownloadPdf = vi.fn()
+vi.mock('../../../hooks/useBrochureDownload', () => ({
+  useBrochureDownload: () => ({
+    isDownloading: false,
+    downloadPdf: mockDownloadPdf,
+  }),
+}))
+
+// Helper para estado inicial del store
+const setupStore = () => {
+  const { setBrochure, setCacheKey, setCompanyName } = useBrochureStore.getState() as BrochureState
+  setCompanyName('Acme Inc')
+  setBrochure('<html><body><h1>Preview</h1></body></html>')
+  setCacheKey('cache-123')
+}
+
+describe('BrochurePreview', () => {
+  beforeEach(async () => {
+    // reset store state between tests
+    useBrochureStore.setState({ companyName: '', brochure: '', cacheKey: '' })
+
+    // Reset language to English before each test
+    await setLanguage('en')
+
+    // Reset mocks
+    mockDownloadPdf.mockReset()
+
+    setupStore()
+  })
+
+  it('muestra textos traducidos en EN por defecto', () => {
+    renderWithProviders(<BrochurePreview />)
+
+    // The component doesn't render visible text, but has aria-labels and titles
+    expect(selectButtonByName(/download pdf/i)).toBeInTheDocument()
+    expect(selectButtonByName(/regenerate brochure/i)).toBeInTheDocument()
+    expect(screen.getByTitle('Brochure preview')).toBeInTheDocument()
+  })
+
+  it('traduce a ES cuando se cambia el idioma', async () => {
+    renderWithProviders(<BrochurePreview />)
+
+    await act(async () => {
+      await setLanguage('es')
+      // Give React time to process all updates including LazyMotion
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    await waitFor(() => {
+      expect(selectButtonByName(/descargar pdf/i)).toBeInTheDocument()
+      expect(selectButtonByName(/volver a generar folleto/i)).toBeInTheDocument()
+      expect(screen.getByTitle('Vista previa del folleto')).toBeInTheDocument()
+    })
+  })
+
+  it('deshabilita el botón cuando no hay brochure', () => {
+    useBrochureStore.setState({ companyName: '', brochure: '', cacheKey: '' })
+    renderWithProviders(<BrochurePreview />)
+
+    // The download button should be disabled when there's no brochure/cache
+    const downloadBtn = selectButtonByName(/download pdf/i)
+    expect(downloadBtn).toBeDisabled()
+  })
+
+  it('muestra skeleton y no muestra iframe cuando isLoading es true', () => {
+    renderWithProviders(<BrochurePreview isLoading />)
+
+    // No debe renderizar el iframe de la vista previa mientras carga
+    expect(screen.queryByTitle('Brochure preview')).not.toBeInTheDocument()
+
+    // Mientras carga, el botón de descarga debe estar deshabilitado
+    const downloadBtn = selectButtonByName(/download pdf/i)
+    expect(downloadBtn).toBeDisabled()
+  })
+
+  it('intenta descargar cuando hay cacheKey', async () => {
+    // Mock successful download result
+    mockDownloadPdf.mockResolvedValueOnce({
+      success: true,
+      blob: makePdfBlob(),
+      filename: 'brochure.pdf',
+    })
+
+    await withBlobUrlSpies(async () => {
+      renderWithProviders(<BrochurePreview />)
+
+      // Click the download button specifically
+      const downloadBtn = selectButtonByName(/download pdf/i)
+      await userEvent.click(downloadBtn)
+
+      // Wait for the download to complete
+      await waitFor(() => {
+        expect(mockDownloadPdf).toHaveBeenCalledWith('cache-123')
+      })
+    })
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom/vitest'
+import { configure } from '@testing-library/react'
+
+// Configure React Testing Library
+configure({
+  asyncUtilTimeout: 2000,
+})
+
+// Silencia el warning: "Received an empty string for a boolean attribute `inert`"
+// Capturamos tanto console.error como console.warn y usamos coincidencia amplia
+const originalConsoleError = console.error
+const originalConsoleWarn = console.warn
+
+function shouldSilenceInertWarning(args: unknown[]) {
+  const [message] = args as [unknown]
+  if (typeof message !== 'string') return false
+  const msg = message.toLowerCase()
+  return msg.includes('inert') && msg.includes('boolean attribute')
+}
+
+console.error = (...args: unknown[]) => {
+  if (shouldSilenceInertWarning(args)) return
+  originalConsoleError(...(args as Parameters<typeof originalConsoleError>))
+}
+
+console.warn = (...args: unknown[]) => {
+  if (shouldSilenceInertWarning(args)) return
+  originalConsoleWarn(...(args as Parameters<typeof originalConsoleWarn>))
+}
+
+// Note: LazyMotion act() warnings are expected and can be safely ignored
+// These come from Framer Motion's internal state management and are not actionable
+// for application developers. The warnings don't indicate test failures or issues.
+
+// Mock matchMedia for components/libraries that use it
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})
+
+// Mock URL.createObjectURL and revokeObjectURL for PDF download tests
+Object.defineProperty(URL, 'createObjectURL', {
+  writable: true,
+  value: (blob: Blob) => `blob:${blob.size}`,
+})
+
+Object.defineProperty(URL, 'revokeObjectURL', {
+  writable: true,
+  value: () => {},
+})
+
+// Mock HTMLAnchorElement.click to avoid jsdom navigation warnings
+Object.defineProperty(HTMLAnchorElement.prototype, 'click', {
+  writable: true,
+  value: function(this: HTMLAnchorElement) {
+    // Simply mock the click without triggering actual navigation or events
+    // This prevents the jsdom "Not implemented: navigation" warning
+    // The test doesn't need to verify the actual click behavior, just that it was called
+  },
+})

--- a/src/test/test-helpers.ts
+++ b/src/test/test-helpers.ts
@@ -1,0 +1,39 @@
+import { screen } from '@testing-library/react'
+import { vitest } from 'vitest'
+
+// Axios-like helpers
+export type AxiosResponse<T> = { data: T; headers: Record<string, unknown> }
+
+export const makeAxiosResponse = <T,>(data: T): AxiosResponse<T> => ({ data, headers: {} })
+
+export const makeAxiosError = (status: number) => ({ isAxiosError: true as const, response: { status } })
+
+export const makeCanceledError = () => ({ isAxiosError: true as const, code: 'ERR_CANCELED', name: 'CanceledError' })
+
+// Language helpers
+export const setLanguage = async (lang: 'en' | 'es') => {
+  const { useLanguageStore } = await import('../stores/useLanguageStore')
+  useLanguageStore.getState().setLanguage(lang)
+}
+
+// DOM testing helpers
+export const selectButtonByName = (name: RegExp) => screen.getByRole('button', { name })
+
+export const getSubmitButton = (container: HTMLElement): HTMLButtonElement => {
+  const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement | null
+  if (!btn) throw new Error('Submit button not found')
+  return btn
+}
+
+export const makePdfBlob = () => new Blob(['fake pdf content'], { type: 'application/pdf' })
+
+export const withBlobUrlSpies = async (run: () => Promise<void> | void) => {
+  const createUrlSpy = vitest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake')
+  const revokeSpy = vitest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+  try {
+    await run()
+  } finally {
+    createUrlSpy.mockRestore()
+    revokeSpy.mockRestore()
+  }
+}

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -1,0 +1,6 @@
+import { render } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { Providers } from '../providers'
+
+export const renderWithProviders = (ui: ReactElement, options?: Parameters<typeof render>[1]) =>
+  render(ui, { wrapper: Providers as React.ComponentType, ...options })


### PR DESCRIPTION
Add BrochurePreview test:

- Test default EN language.
- Test translate test when set ES language.
- Test the disabled download button when the brochure is empty
- Test shows skeleton and doesn't iframe when isLoading is true. 
- Test downloading the brochure when cache_key isn't empty.

Add setup test:
- Prevent the warning:
"Received an empty string for a boolean attribute `inert`"
by adjusting the setup configuration.
- Mock different objects.

Add Test Helpers and Test utils for using reusable configuration. 