### PR TITLE
refactor(stores): move type definitions to shared types file

### DIFF
--- a/src/hooks/useBrochureSubmit.ts
+++ b/src/hooks/useBrochureSubmit.ts
@@ -1,22 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
-import axios, { isAxiosError } from 'axios'
-import { API_BASE_URL } from '../config'
+import { apiPost, isAxiosError } from '../services/http'
 
 import { useBrochureStore } from '../stores/useBrochureStore'
 import { useBrochuresRemainingStore } from '../stores/useBrochuresRemaining'
 import { useAnonIdStore } from '../stores/useAnonId'
-import type {LanguageStore} from '../stores/useLanguageStore'
-
-export interface BrochureSubmitData {
-  companyName: string
-  url: string
-  language: LanguageStore
-  brochureType: 'professional' | 'funny'
-}
-
-export type BrochureSubmitResult =
-  | { success: true }
-  | { success: false; status?: number; error?: unknown }
+import type { BrochureSubmitData, BrochureSubmitResult } from '../types'
 
 export const useBrochureSubmit = () => {
   const [isLoading, setIsLoading] = useState(false)
@@ -43,8 +31,8 @@ export const useBrochureSubmit = () => {
     controllerRef.current = controller
 
     try {
-      const response = await axios.post(
-        `${API_BASE_URL}/api/v1/create_brochure`,
+      const response = await apiPost(
+        '/api/v1/create_brochure',
         {
           anon_id: anonId,
           company_name: data.companyName,
@@ -58,9 +46,9 @@ export const useBrochureSubmit = () => {
         }
       )
 
-      setBrochure(response.data.brochure)
-      setCacheKey(response.data.cache_key)
-      setBrochuresRemaining(response.data.brochures_remaining)
+      setBrochure((response.data as { brochure: string }).brochure)
+      setCacheKey((response.data as { cache_key: string }).cache_key)
+      setBrochuresRemaining((response.data as { brochures_remaining: number }).brochures_remaining)
 
       // Persistimos la "última sumisión válida" sólo tras éxito
       setLastSubmission({

--- a/src/stores/useBrochureStore.ts
+++ b/src/stores/useBrochureStore.ts
@@ -1,20 +1,20 @@
 import {create} from 'zustand'
-import type { LanguageStore } from './useLanguageStore'
+import type { LanguageStore, BrochureType } from '../types'
 
 export interface BrochureState {
   companyName: string
   url: string
   language: LanguageStore
   brochure: string
-  brochureType: 'professional' | 'funny'
+  brochureType: BrochureType
   cacheKey: string
   setBrochure: (brochure: string) => void
   setCompanyName: (companyName: string) => void
   setCacheKey: (cacheKey: string) => void
   setUrl: (url: string) => void
   setLanguage: (language: LanguageStore) => void
-  setBrochureType: (brochureType: 'professional' | 'funny') => void
-  setLastSubmission: (payload: { companyName: string; url: string; language: LanguageStore; brochureType: 'professional' | 'funny' }) => void
+  setBrochureType: (brochureType: BrochureType) => void
+  setLastSubmission: (payload: { companyName: string; url: string; language: LanguageStore; brochureType: BrochureType }) => void
 }
 
 export const useBrochureStore = create<BrochureState>((set) => {

--- a/src/stores/useLanguageStore.ts
+++ b/src/stores/useLanguageStore.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-
-export type LanguageStore = 'en' | 'es'	
+import type { LanguageStore } from '../types'
 
 interface LanguageState {
   language: LanguageStore


### PR DESCRIPTION
- Consolidate LanguageStore and BrochureType definitions in central types file
- Replace direct axios calls with apiPost service abstraction
- Update type imports across multiple files for consistency