### PR TITLE
refactor: remove console.error in getBrochuresRemaining error handling

### DIFF
--- a/src/services/getBrochuresRemaining.ts
+++ b/src/services/getBrochuresRemaining.ts
@@ -13,7 +13,6 @@ export const getBrochuresRemaining = async (
     })
     return { success: true, data: res.data as GetBrochuresRemainingResponse }
   } catch (err) {
-    console.error("getBrochuresRemaining failed", err)
     return { success: false, error: err }
   }
 }


### PR DESCRIPTION
Remove console.error in getBrochuresRemaining. This change improves best practices score in Lighthouse.

Before:

<img width="464" height="294" alt="Captura de pantalla 2025-09-18 163803" src="https://github.com/user-attachments/assets/7bdb8914-f59a-4600-b25d-5b16ba724932" />

After:

<img width="469" height="430" alt="Captura de pantalla 2025-09-18 190124" src="https://github.com/user-attachments/assets/1d473c1d-f7b6-470b-82d3-813f11604152" />
